### PR TITLE
chore: :memo: Add mqt-core issue templates to repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,38 +1,45 @@
----
-name: Bug report
-about: Create a report to help us improve
-title: ''
-labels: ''
-assignees: ''
+name: 🐛 Bug report
+description: Something is not working correctly.
+title: "🐛 <title>"
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        **Thank you for wanting to report a bug for this project!**
 
----
+        ⚠
+        Verify first that your issue is not [already reported on GitHub](https://github.com/cda-tum/mqt-qubomaker/search?q=is%3Aissue&type=issues).
 
-**Describe the bug**
-A clear and concise description of what the bug is.
-
-**To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
-
-**Expected behavior**
-A clear and concise description of what you expected to happen.
-
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
-
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
-
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
-
-**Additional context**
-Add any other context about the problem here.
+        If you have general questions, please consider [starting a discussion](https://github.com/cda-tum/mqt-qubomaker/discussions).
+  - type: textarea
+    attributes:
+      label: Environment information
+      description: >-
+        Please provide information about your environment. For example, OS, Python version, mqt.qubomaker version etc.
+      placeholder: |
+        - OS:
+        - Python version:
+        - mqt.qubomaker version:
+        - Additional environment information:
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected behavior
+      description: A clear and concise description of what you expected to happen.
+  - type: textarea
+    attributes:
+      label: How to Reproduce
+      description: Please provide steps to reproduce this bug.
+      placeholder: |
+        1. Get package from '...'
+        2. Then run '...'
+        3. An error occurs.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,44 +2,39 @@ name: 🐛 Bug report
 description: Something is not working correctly.
 title: "🐛 <title>"
 body:
-  - type: markdown
-    attributes:
-      value: >-
-        **Thank you for wanting to report a bug for this project!**
 
-        ⚠
-        Verify first that your issue is not [already reported on GitHub](https://github.com/cda-tum/mqt-qubomaker/search?q=is%3Aissue&type=issues).
+- type: markdown
+  attributes:
+  value: >-
+  **Thank you for wanting to report a bug for this project!**
 
-        If you have general questions, please consider [starting a discussion](https://github.com/cda-tum/mqt-qubomaker/discussions).
-  - type: textarea
-    attributes:
-      label: Environment information
-      description: >-
-        Please provide information about your environment. For example, OS, Python version, mqt.qubomaker version etc.
-      placeholder: |
-        - OS:
-        - Python version:
-        - mqt.qubomaker version:
-        - Additional environment information:
-    validations:
-      required: true
-  - type: textarea
-    attributes:
-      label: Description
-      description: A clear and concise description of what the bug is.
-    validations:
-      required: true
-  - type: textarea
-    attributes:
-      label: Expected behavior
-      description: A clear and concise description of what you expected to happen.
-  - type: textarea
-    attributes:
-      label: How to Reproduce
-      description: Please provide steps to reproduce this bug.
-      placeholder: |
-        1. Get package from '...'
-        2. Then run '...'
-        3. An error occurs.
-    validations:
-      required: true
+      ⚠
+      Verify first that your issue is not [already reported on GitHub](https://github.com/cda-tum/mqt-qubomaker/search?q=is%3Aissue&type=issues).
+
+      If you have general questions, please consider [starting a discussion](https://github.com/cda-tum/mqt-qubomaker/discussions).
+
+- type: textarea
+  attributes:
+  label: Environment information
+  description: >-
+  Please provide information about your environment. For example, OS, Python version, mqt.qubomaker version etc.
+  placeholder: | - OS: - Python version: - mqt.qubomaker version: - Additional environment information:
+  validations:
+  required: true
+- type: textarea
+  attributes:
+  label: Description
+  description: A clear and concise description of what the bug is.
+  validations:
+  required: true
+- type: textarea
+  attributes:
+  label: Expected behavior
+  description: A clear and concise description of what you expected to happen.
+- type: textarea
+  attributes:
+  label: How to Reproduce
+  description: Please provide steps to reproduce this bug.
+  placeholder: | 1. Get package from '...' 2. Then run '...' 3. An error occurs.
+  validations:
+  required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,31 +2,32 @@ name: ✨ Feature request
 description: Suggest an idea
 title: "✨ <title>"
 body:
-  - type: markdown
-    attributes:
-      value: >
-        **Thank you for wanting to suggest a feature for this project!**
 
-        ⚠
-        Verify first that your idea is not [already requested on GitHub](https://github.com/cda-tum/mqt-qubomaker/search?q=is%3Aissue&type=issues).
+- type: markdown
+  attributes:
+  value: >
+  **Thank you for wanting to suggest a feature for this project!**
 
-  - type: textarea
-    attributes:
-      label: What's the problem this feature will solve?
-      description: >-
-        What are you trying to do, that you are unable to achieve as it currently stands?
-      placeholder: >-
-        I'm trying to do X and I'm missing feature Y for this to be
-        easily achievable.
-    validations:
-      required: true
+      ⚠
+      Verify first that your idea is not [already requested on GitHub](https://github.com/cda-tum/mqt-qubomaker/search?q=is%3Aissue&type=issues).
 
-  - type: textarea
-    attributes:
-      label: Describe the solution you'd like
-      description: >
-        Clear and concise description of what you want to happen.
-      placeholder: >-
-        When I do X, I want to achieve Y in a situation when Z.
-    validations:
-      required: true
+- type: textarea
+  attributes:
+  label: What's the problem this feature will solve?
+  description: >-
+  What are you trying to do, that you are unable to achieve as it currently stands?
+  placeholder: >-
+  I'm trying to do X and I'm missing feature Y for this to be
+  easily achievable.
+  validations:
+  required: true
+
+- type: textarea
+  attributes:
+  label: Describe the solution you'd like
+  description: >
+  Clear and concise description of what you want to happen.
+  placeholder: >-
+  When I do X, I want to achieve Y in a situation when Z.
+  validations:
+  required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,20 +1,32 @@
----
-name: Feature request
-about: Suggest an idea for this project
-title: ''
-labels: ''
-assignees: ''
+name: ✨ Feature request
+description: Suggest an idea
+title: "✨ <title>"
+body:
+  - type: markdown
+    attributes:
+      value: >
+        **Thank you for wanting to suggest a feature for this project!**
 
----
+        ⚠
+        Verify first that your idea is not [already requested on GitHub](https://github.com/cda-tum/mqt-qubomaker/search?q=is%3Aissue&type=issues).
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+  - type: textarea
+    attributes:
+      label: What's the problem this feature will solve?
+      description: >-
+        What are you trying to do, that you are unable to achieve as it currently stands?
+      placeholder: >-
+        I'm trying to do X and I'm missing feature Y for this to be
+        easily achievable.
+    validations:
+      required: true
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
-
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
-
-**Additional context**
-Add any other context or screenshots about the feature request here.
+  - type: textarea
+    attributes:
+      label: Describe the solution you'd like
+      description: >
+        Clear and concise description of what you want to happen.
+      placeholder: >-
+        When I do X, I want to achieve Y in a situation when Z.
+    validations:
+      required: true


### PR DESCRIPTION
This pull request adds the issue templates from mqt-core to this repo (slightly modified to fit to the project structure/requirements).