### PR TITLE
docs: Fix typos in README.md and QUBOGenerator docstring

### DIFF
--- a/src/mqt/qubomaker/pathfinder/README.md
+++ b/src/mqt/qubomaker/pathfinder/README.md
@@ -42,7 +42,7 @@ The `pathfinder` module provides cost functions representing various constraints
 - `PathIsValid`: Checks, whether the encoding represents a valid path. Should be included in most cases.
 - `PathPositionIs`: Enforces that one of a set of vertices is located at a given position of a graph.
 - `PathStartsAt`: Enforces that one of a set of vertices is located at the start of a graph.
-- `PathEndsAt`: Enforces that one of a set of vertices is located the the end of a graph.
+- `PathEndsAt`: Enforces that one of a set of vertices is located at the end of a graph.
 - `PathContainsVerticesExactlyOnce`: Enforces that each element of a given set of vertices appears exactly once in a path.
 - `PathContainsVerticesAtLeastOnce`: Enforces that each element of a given set of vertices appears at least once in a path.
 - `PathContainsVerticesAtMostOnce`: Enforces that each element of a given set of vertices appears at most once in a path.

--- a/src/mqt/qubomaker/qubo_generator.py
+++ b/src/mqt/qubomaker/qubo_generator.py
@@ -325,7 +325,7 @@ class QUBOGenerator:
             assignment (list[int]): The assignment for the encoding variables `x_i`.
 
         Returns:
-            dict[sp.Expr, int]: An assignment dictionary, mappingeach `y_k` to its value in {0, 1}.
+            dict[sp.Expr, int]: An assignment dictionary, mapping each `y_k` to its value in {0, 1}.
         """
         auxiliary_values: dict[sp.Expr, int] = {}
         encoding_variables = dict(self._get_encoding_variables())


### PR DESCRIPTION
## Fix minor typos
- located the the end  -> located at the end
- mappingeach -> mapping each